### PR TITLE
Update Heatmap.class.php

### DIFF
--- a/classes/Heatmap.class.php
+++ b/classes/Heatmap.class.php
@@ -56,7 +56,7 @@ class Heatmap
 	/* @var integer $__grey Niveau du gris (couleur du 0 clic) / Grey level (color of no-click) */
 	var $__grey = 240;
 
-	function Heatmap()
+	function __construct()
 	{
 		$this->alpha = min($this->alpha, 127);
 	}


### PR DESCRIPTION
PHP version update to 7.x
Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; Heatmap has a deprecated constructor